### PR TITLE
Followed example on allowing for platform differences

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,7 +1,8 @@
+import domtoimage from 'dom-to-image';
 import * as ImagePicker from 'expo-image-picker';
 import * as MediaLibrary from 'expo-media-library';
 import { useEffect, useRef, useState } from "react";
-import { ImageSourcePropType, StyleSheet, View } from "react-native";
+import { ImageSourcePropType, Platform, StyleSheet, View } from "react-native";
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { captureRef } from 'react-native-view-shot';
 
@@ -52,19 +53,40 @@ export default function Index() {
   };
 
   const onSaveImageAsync = async () => {
-    try {
-      const localUri = await captureRef(imageRef, {
-        height: 440,
-        quality: 1,
-      });
+    // Non web
+    if (Platform.OS != 'web'){
+      try {
+        const localUri = await captureRef(imageRef, {
+          height: 440,
+          quality: 1,
+        });
 
-      await MediaLibrary.saveToLibraryAsync(localUri);  // Save the variable
+        await MediaLibrary.saveToLibraryAsync(localUri);  // Save the variable
 
-      if (localUri) {
-        alert("Your image has been saved!")   // The uri will exist if the capture was a success
+        if (localUri) {
+          alert("Your image has been saved!")   // The uri will exist if the capture was a success
+        }
+      } catch (e) {   // If the caputure was not a success
+        console.log(e)
+    }}
+    // Web
+    else {
+      try { // Try to capture image
+        const dataUrl = await domtoimage.toJpeg(imageRef.current, {
+          quality: 0.95,
+          width: 320,
+          height: 440,
+        });
+
+        // Dowmload it to computer
+        let link = document.createElement('a');
+        link.download = 'sticker-smash.jpeg';
+        link.href = dataUrl;
+        link.click();
+
+      } catch (e) {
+        console.log(e)
       }
-    } catch (e) {   // If the caputure was not a success
-      console.log(e)
     }
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
+        "dom-to-image": "^2.6.0",
         "expo": "~54.0.9",
         "expo-constants": "~18.0.9",
         "expo-font": "~14.0.8",
@@ -5857,6 +5858,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-to-image": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/dom-to-image/-/dom-to-image-2.6.0.tgz",
+      "integrity": "sha512-Dt0QdaHmLpjURjU7Tnu3AgYSF2LuOmksSGsUcE6ItvJoCWTBEmiMXcqBdNSAm9+QbbwD7JMoVsuuKX6ZVQv1qA==",
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.4.7",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
+    "dom-to-image": "^2.6.0",
     "expo": "~54.0.9",
     "expo-constants": "~18.0.9",
     "expo-font": "~14.0.8",


### PR DESCRIPTION
The main takeaway is to understand when the tools you're using won't work on every platform. Then use `Platform.OS` (from react-native) to check what platform you're using. In this example, the difference was saving the image file.